### PR TITLE
修复 标星历史图表无法显示的问题

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,10 +108,10 @@ V2 版本是对 V1 版本的全面升级，最显著的提升就是 安装包的
 ### 标星历史
 
 
-<a href="https://www.star-history.com/#GlossMod/Gloss-Mod-Manager&type=date&legend=top-left">
+<a href="https://star-history.dera.page/#GlossMod/Gloss-Mod-Manager&type=date&legend=top-left">
  <picture>
-   <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/svg?repos=GlossMod/Gloss-Mod-Manager&type=date&theme=dark&legend=top-left" />
-   <source media="(prefers-color-scheme: light)" srcset="https://api.star-history.com/svg?repos=GlossMod/Gloss-Mod-Manager&type=date&legend=top-left" />
-   <img alt="Star History Chart" src="https://api.star-history.com/svg?repos=GlossMod/Gloss-Mod-Manager&type=date&legend=top-left" />
+   <source media="(prefers-color-scheme: dark)" srcset="https://star-history.dera.page/svg?repos=GlossMod/Gloss-Mod-Manager&type=date&theme=dark&legend=top-left" />
+   <source media="(prefers-color-scheme: light)" srcset="https://star-history.dera.page/svg?repos=GlossMod/Gloss-Mod-Manager&type=date&legend=top-left" />
+   <img alt="Star History Chart" src="https://star-history.dera.page/svg?repos=GlossMod/Gloss-Mod-Manager&type=date&legend=top-left" />
  </picture>
 </a>


### PR DESCRIPTION
当前 README 中的标星历史图表因为原有服务不可用而无法正常加载，导致项目页面缺少 star 增长趋势展示。
此 PR 将图表更新为可正常工作的地址，使该模块恢复显示，顺带保持对整个项目的贡献页展示也无障碍。